### PR TITLE
CI: adopt ArmorSkin's build workflow + add automated deploy pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,10 @@
 # against bad commits.
 
 name: build
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,28 +15,45 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          25,    # Minimum Java version supported by Minecraft
+          25,    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
+        os: [ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
+
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
+
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          # Cache resolved dependencies so a working build doesn't re-download
+          # them every run (and so transient maven outages are less impactful).
+          cache: 'gradle'
+
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
+
+      # The Modmenu/Cloth Config mavens occasionally drop the connection
+      # mid-download (HTTP/2 stream reset / "premature end of chunk"). Retry the
+      # build a few times so a single flaky download doesn't fail the whole job.
       - name: build
-        run: ./gradlew build
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ./gradlew build
+
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,113 @@
+# Publishes builds to GitHub Releases and Modrinth.
+#
+# - Manual run (Actions tab -> Run workflow) on any branch other than
+#   `unstable` publishes an ALPHA build of that branch.
+# - Manual run on `unstable` publishes a BETA build.
+# - Every push to `main` automatically publishes a RELEASE build, but only if
+#   gradle.properties' mod_version has actually changed since the last
+#   release tag (so merges that don't bump the version don't spam a release).
+
+name: deploy
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # need full tag history for the release-version-change check below
+
+      - name: resolve deploy channel and version
+        id: vars
+        run: |
+          mod_version=$(grep -E '^[[:space:]]*mod_version[[:space:]]*=' gradle.properties | sed -E 's/^[[:space:]]*mod_version[[:space:]]*=[[:space:]]*//' | tr -d '[:space:]')
+          mc_version=$(grep -E '^[[:space:]]*minecraft_version[[:space:]]*=' gradle.properties | sed -E 's/^[[:space:]]*minecraft_version[[:space:]]*=[[:space:]]*//' | tr -d '[:space:]')
+          run_number="${{ github.run_number }}"
+          branch="${{ github.ref_name }}"
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            channel=release
+          elif [ "$branch" = "unstable" ]; then
+            channel=beta
+          else
+            channel=alpha
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "mc_version=$mc_version" >> "$GITHUB_OUTPUT"
+
+          if [ "$channel" = "release" ]; then
+            latest_tag=$(git tag -l 'v*' | grep -vE -- '-BETA-|-ALPHA-' | sort -V | tail -1 | sed 's/^v//')
+            if [ "$latest_tag" = "$mod_version" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "mod_version ($mod_version) unchanged since latest release tag (v$latest_tag) - skipping release."
+              exit 0
+            fi
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "tag=v${mod_version}" >> "$GITHUB_OUTPUT"
+            echo "release_name=RemoveHUD v${mod_version} RELEASE" >> "$GITHUB_OUTPUT"
+            echo "version_number=v${mod_version}+${mc_version}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          elif [ "$channel" = "beta" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "tag=v${mod_version}-BETA-${run_number}" >> "$GITHUB_OUTPUT"
+            echo "release_name=RemoveHUD ${mod_version} BETA ${run_number}" >> "$GITHUB_OUTPUT"
+            echo "version_number=v${mod_version}-beta.${run_number}+${mc_version}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "tag=v${mod_version}-ALPHA-${run_number}" >> "$GITHUB_OUTPUT"
+            echo "release_name=RemoveHUD ${mod_version} ALPHA ${run_number} (${branch})" >> "$GITHUB_OUTPUT"
+            echo "version_number=v${mod_version}-alpha.${run_number}+${mc_version}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: validate gradle wrapper
+        if: steps.vars.outputs.skip != 'true'
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: setup jdk 25
+        if: steps.vars.outputs.skip != 'true'
+        uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      # The Modmenu/Cloth Config mavens occasionally drop the connection
+      # mid-download (HTTP/2 stream reset / "premature end of chunk"). Retry
+      # the build a few times so a single flaky download doesn't fail the job.
+      - name: build
+        if: steps.vars.outputs.skip != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ./gradlew build
+
+      - name: publish to github releases and modrinth
+        if: steps.vars.outputs.skip != 'true'
+        uses: Kira-NT/mc-publish@v3
+        with:
+          name: ${{ steps.vars.outputs.release_name }}
+          version: ${{ steps.vars.outputs.version_number }}
+          version-type: ${{ steps.vars.outputs.channel }}
+          game-versions: ${{ steps.vars.outputs.mc_version }}
+          loaders: fabric
+
+          modrinth-id: MiPOIx6b
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          github-tag: ${{ steps.vars.outputs.tag }}
+          github-commitish: ${{ github.sha }}
+          github-generate-changelog: true
+          github-prerelease: ${{ steps.vars.outputs.prerelease }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `build.yml`: adopts the same build workflow used on ArmorSkin — modern actions, Gradle dependency caching, and a retry wrapper around the build step for the known-flaky shedaniel/terraformersmc maven downloads ("premature end of chunk" errors). Also moves off the deprecated `ubuntu-20.04` runner image.
- `deploy.yml` (new): publishes to GitHub Releases + Modrinth via [mc-publish](https://github.com/Kira-NT/mc-publish).
  - Manual dispatch (Actions tab → Run workflow) on any branch other than `unstable` → **alpha** build.
  - Manual dispatch on `unstable` → **beta** build.
  - Every push to `main` → automatic **release** build, but only if `gradle.properties`' `mod_version` actually changed since the last release tag (won't fire on a no-version-bump merge, and won't fail on a duplicate tag).
  - Tag/name/version conventions match the existing GitHub Releases and Modrinth history for this project (researched via the GitHub and Modrinth APIs before writing this).

Needs the `MODRINTH_TOKEN` repo secret, which is already set.

## Test plan
- [x] Validated both workflow files parse as YAML
- [x] Validated the mod_version/mc_version extraction and release-skip-gate shell logic locally against the real `gradle.properties` and tag history (correctly detects `1.4.0` == latest tag `v1.4.0` and would skip; correctly would not skip if bumped)
- [ ] Once merged, trigger a real alpha run (`gh workflow run deploy.yml --ref <branch>`) to confirm a GitHub prerelease + Modrinth alpha version both get created correctly end-to-end — this can't be tested pre-merge since `workflow_dispatch` workflows must exist on the default branch before GitHub will let them be dispatched at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)